### PR TITLE
Callbacks fix for RTX2

### DIFF
--- a/source/client_a.cpp
+++ b/source/client_a.cpp
@@ -27,7 +27,7 @@ struct box_context {
 static const UvisorBoxAclItem acl[] = {
 };
 
-static void client_a_main(const void *);
+static void client_a_main(void *);
 
 /* Box configuration
  * This box has a smaller interrupt and main thread stack sizes as we do nothing
@@ -86,7 +86,7 @@ static void box_sync_runner(void)
     }
 }
 
-static void client_a_main(const void *)
+static void client_a_main(void *)
 {
     /* Create new threads. */
     /* Note: The stack must be at least 1kB since threads will use printf. */

--- a/source/client_b.cpp
+++ b/source/client_b.cpp
@@ -28,7 +28,7 @@ static const UvisorBoxAclItem acl[] = {
     /* This secure box is pure software, no secure peripherals are required. */
 };
 
-static void client_b_main(const void *);
+static void client_b_main(void *);
 
 /* Box configuration
  * This box has a smaller interrupt stack size as we do nothing special in it.
@@ -50,7 +50,7 @@ static uint32_t get_a_number()
     return (uvisor_ctx->number -= 300UL);
 }
 
-static void client_b_main(const void *)
+static void client_b_main(void *)
 {
     /* The entire box code runs in its main thread. */
     while (1) {

--- a/source/secure_number.cpp
+++ b/source/secure_number.cpp
@@ -29,7 +29,7 @@ struct box_context {
 static const UvisorBoxAclItem acl[] = {
 };
 
-static void number_store_main(const void *);
+static void number_store_main(void *);
 static uint32_t get_number(void);
 static int set_number(uint32_t number);
 
@@ -106,7 +106,7 @@ static int set_number(uint32_t number)
     return 0;
 }
 
-static void number_store_main(const void *)
+static void number_store_main(void *)
 {
     /* Today we only allow client a to write to the number. */
     uvisor_ctx->trusted_id = -1;


### PR DESCRIPTION
Remove const as the function pointer declaration has changed in RTX2

This is set to go to master , please change it as it wont build with the current mbed-os (the fpt declaration is different).

Before this patch:

```
[Error] box_config.h@158,5: invalid conversion from 'void (*)(const void*)' to 'void (*)(void*)' [-fpermissive]
[ERROR] In file included from ./mbed-os/features/FEATURE_UVISOR/includes/uvisor/api/inc/uvisor-lib.h:29:0,
                 from ./mbed-os/features/FEATURE_UVISOR/includes/uvisor-lib/uvisor-lib.h:42,
                 from .\source\secure_number.cpp:17:
./mbed-os/features/FEATURE_UVISOR/includes/uvisor/api/inc/box_config.h:158:5: error: invalid conversion from 'void (*)(const void*)' to 'void (*)(void*)' [-fpermissive]
     }; \
     ^
.\source\secure_number.cpp:39:1: note: in expansion of macro 'UVISOR_BOX_MAIN'
 UVISOR_BOX_MAIN(number_store_main, osPriorityNormal, UVISOR_BOX_STACK_SIZE);
 ^

[mbed] ERROR: "c:\python27\python.exe" returned error code 1.
```

After:

```
Link: mbed-os-example-uvisor-number-store
Elf2Bin: mbed-os-example-uvisor-number-store
+--------------------------+-------+-------+------+
| Module                   | .text | .data | .bss |
+--------------------------+-------+-------+------+
| Fill                     |   132 |     4 | 2253 |
| Misc                     | 59816 |  1184 |  416 |
| drivers                  |  1059 |     0 |    0 |
| features/FEATURE_UVISOR  |   944 |     0 |    1 |
| features/filesystem      |   657 |     0 |    0 |
| features/netsocket       |    22 |     0 |    0 |
| features/storage         |    42 |     0 |  184 |
| hal                      |   450 |     0 |    8 |
| platform                 |  2918 |     0 |  369 |
| rtos                     |  1309 |     4 | 4368 |
| rtos/rtx2                |  8785 |   176 |  745 |
| targets/TARGET_Freescale | 10364 |    12 |  412 |
| Subtotals                | 86498 |  1380 | 8756 |
+--------------------------+-------+-------+------+
Allocated Heap: 24580 bytes
Allocated Stack: unknown
Total Static RAM memory (data + bss): 10136 bytes
Total RAM memory (data + bss + heap + stack): 34716 bytes
Total Flash memory (text + data + misc): 88918 bytes

Image: .\BUILD\K64F\GCC_ARM\mbed-os-example-uvisor-number-store.bin
```