### PR TITLE
Increase client a stack size

### DIFF
--- a/source/client_a.cpp
+++ b/source/client_a.cpp
@@ -34,7 +34,7 @@ static void client_a_main(const void *);
  * special in them. */
 UVISOR_BOX_NAMESPACE("client_a");
 UVISOR_BOX_HEAPSIZE(3072);
-UVISOR_BOX_MAIN(client_a_main, osPriorityNormal, 512);
+UVISOR_BOX_MAIN(client_a_main, osPriorityNormal, 768);
 UVISOR_BOX_CONFIG(secure_number_client_a, acl, 512, box_context);
 
 /* FIXME: The guard is needed for backwards-compatibility reasons. Remove it


### PR DESCRIPTION
The client-a main functions was overwriting the `osRtxStackMagicWord` and thus `osRtxThreadStackCheck()` failed, calling `mbed_die()`, which fails on uVisor.

cc @AlessandroA @Patater 